### PR TITLE
rename collateral to receivable in the entire codebase

### DIFF
--- a/contracts/BasePool.sol
+++ b/contracts/BasePool.sol
@@ -49,9 +49,9 @@ abstract contract BasePool is HDT, ILiquidityProvider, IPool, Ownable {
     // the default APR for the pool in terms of basis points.
     uint256 internal poolAprInBps;
 
-    // Percentage of collateral required for credits in this pool in terms of bais points
-    // For over collateralization, use more than 100%, for no collateral, use 0.
-    uint256 internal collateralRequiredInBps;
+    // Percentage of receivable required for credits in this pool in terms of bais points
+    // For over receivableization, use more than 100%, for no receivable, use 0.
+    uint256 internal receivableRequiredInBps;
 
     // whether the pool is ON or OFF
     PoolStatus public status = PoolStatus.Off;
@@ -237,17 +237,17 @@ abstract contract BasePool is HDT, ILiquidityProvider, IPool, Ownable {
     }
 
     /**
-     * @notice Set the collateral rate in terms of basis points. 
-     @ param _collateralInBps the percentage. A percentage over 10000 means overcollateralization.
+     * @notice Set the receivable rate in terms of basis points. 
+     @ param _receivableInBps the percentage. A percentage over 10000 means overreceivableization.
      */
-    function setCollateralRequiredInBps(uint256 _collateralInBps)
+    function setReceivableRequiredInBps(uint256 _receivableInBps)
         external
         virtual
         override
     {
         onlyOwnerOrHumaMasterAdmin();
-        require(_collateralInBps <= 10000, "INVALID_COLLATERAL_IN_BPS");
-        collateralRequiredInBps = _collateralInBps;
+        require(_receivableInBps <= 10000, "INVALID_COLLATERAL_IN_BPS");
+        receivableRequiredInBps = _receivableInBps;
     }
 
     /**

--- a/contracts/InvoiceFactoring.sol
+++ b/contracts/InvoiceFactoring.sol
@@ -43,9 +43,9 @@ contract InvoiceFactoring is
      * the borrower to drawdown (borrow) from the approved credit.
      * @param _borrower the borrower address
      * @param _creditAmount the limit of the credit
-     * @param _collateralAsset the collateral asset used for this credit
-     * @param _collateralParam additional parameter of the collateral asset, e.g. NFT tokenid
-     * @param _collateralAmount amount of the collateral asset
+     * @param _receivableAsset the receivable asset used for this credit
+     * @param _receivableParam additional parameter of the receivable asset, e.g. NFT tokenid
+     * @param _receivableAmount amount of the receivable asset
      * @param _intervalInDays time interval for each payback in units of days
      * @param _remainingPeriods the number of pay periods for this credit
      * @dev Only Evaluation Agents for this contract can call this function.
@@ -53,9 +53,9 @@ contract InvoiceFactoring is
     function recordPreapprovedCredit(
         address _borrower,
         uint256 _creditAmount,
-        address _collateralAsset,
-        uint256 _collateralParam,
-        uint256 _collateralAmount,
+        address _receivableAsset,
+        uint256 _receivableParam,
+        uint256 _receivableAmount,
         uint256 _intervalInDays,
         uint256 _remainingPeriods
     ) public virtual override {
@@ -65,9 +65,9 @@ contract InvoiceFactoring is
         initiate(
             _borrower,
             _creditAmount,
-            _collateralAsset,
-            _collateralParam,
-            _collateralAmount,
+            _receivableAsset,
+            _receivableParam,
+            _receivableAmount,
             poolAprInBps,
             _intervalInDays,
             _remainingPeriods

--- a/contracts/interfaces/ICredit.sol
+++ b/contracts/interfaces/ICredit.sol
@@ -12,12 +12,12 @@ interface ICredit {
 
     function drawdown(uint256 _borrowAmount) external;
 
-    function drawdownWithCollateral(
+    function drawdownWithReceivable(
         address _borrower,
         uint256 borrowAmount,
-        address collateralAsset,
-        uint256 collateralParam,
-        uint256 collateralCount
+        address receivableAsset,
+        uint256 receivableParam,
+        uint256 receivableCount
     ) external;
 
     function invalidateApprovedCredit(address _borrower) external;

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -13,7 +13,7 @@ interface IPool {
 
     // function setKeySettings(
     //     uint256 _apr,
-    //     uint256 _collateralRateInBps,
+    //     uint256 _receivableRateInBps,
     //     uint256 _minAmount,
     //     uint256 _maxAmount,
     //     uint256 _front_fee_flat,
@@ -29,7 +29,7 @@ interface IPool {
 
     function setAPR(uint256 _apr) external;
 
-    function setCollateralRequiredInBps(uint256 _collateralRateInBps) external;
+    function setReceivableRequiredInBps(uint256 _receivableRateInBps) external;
 
     function setMinMaxBorrowAmount(uint256 _minAmount, uint256 _maxAmount)
         external;

--- a/contracts/interfaces/IPreaprrovedCredit.sol
+++ b/contracts/interfaces/IPreaprrovedCredit.sol
@@ -8,18 +8,18 @@ interface IPreapprovedCredit {
     /**
      * @param _borrower the borrower address
      * @param _creditAmount the limit of the credit
-     * @param _collateralAsset the collateral asset used for this credit
-     * @param _collateralParam additional parameter of the collateral asset, e.g. NFT tokenid
-     * @param _collateralAmount amount of the collateral asset
+     * @param _receivableAsset the receivable asset used for this credit
+     * @param _receivableParam additional parameter of the receivable asset, e.g. NFT tokenid
+     * @param _receivableAmount amount of the receivable asset
      * @param _intervalInDays time interval for each payback in units of days
      * @param _remainingPeriods the number of pay periods for this credit
      */
     function recordPreapprovedCredit(
         address _borrower,
         uint256 _creditAmount,
-        address _collateralAsset,
-        uint256 _collateralAmount,
-        uint256 _collateralParam,
+        address _receivableAsset,
+        uint256 _receivableAmount,
+        uint256 _receivableParam,
         uint256 _intervalInDays,
         uint256 _remainingPeriods
     ) external;

--- a/contracts/libraries/BaseStructs.sol
+++ b/contracts/libraries/BaseStructs.sol
@@ -26,15 +26,13 @@ library BaseStructs {
     }
 
     /**
-     * @notice CollateralInfo stores collateral used for credits.
-     * @dev Used uint88 for collateralAmount to pack the entire struct in 2 storage units
-     * @dev deleted is used to mark the entry as deleted in mappings
-     * @dev collateralParam is used to store info such as NFT tokenId
+     * @notice ReceivableInfo stores receivable used for credits.
+     * @dev receivableParam is used to store info such as NFT tokenId
      */
-    struct CollateralInfo {
-        address collateralAsset;
-        uint96 collateralAmount;
-        uint256 collateralParam;
+    struct ReceivableInfo {
+        address receivableAsset;
+        uint96 receivableAmount;
+        uint256 receivableParam;
     }
 
     enum CreditState {

--- a/test/InvoiceFactoringTest.js
+++ b/test/InvoiceFactoringTest.js
@@ -266,7 +266,7 @@ describe("Huma Invoice Financing", function() {
       await expect(
         invoiceContract
           .connect(borrower)
-          .drawdownWithCollateral(
+          .drawdownWithReceivable(
             borrower.address,
             1,
             invoiceNFTContract.address,
@@ -281,7 +281,7 @@ describe("Huma Invoice Financing", function() {
 
       await invoiceContract
         .connect(borrower)
-        .drawdownWithCollateral(
+        .drawdownWithReceivable(
           borrower.address,
           200,
           invoiceNFTContract.address,
@@ -305,7 +305,7 @@ describe("Huma Invoice Financing", function() {
 
       await invoiceContract
         .connect(borrower)
-        .drawdownWithCollateral(
+        .drawdownWithReceivable(
           borrower.address,
           400,
           invoiceNFTContract.address,
@@ -356,7 +356,7 @@ describe("Huma Invoice Financing", function() {
 
       await invoiceContract
         .connect(borrower)
-        .drawdownWithCollateral(
+        .drawdownWithReceivable(
           borrower.address,
           400,
           invoiceNFTContract.address,


### PR DESCRIPTION
We do not plan to use collateral in v1. Instead, we will use receivables to back the credits originated from Huma protocol. Updated the terminology in the entire codebase to use receivable. 