### PR TITLE
Add inactivity check and last interaction time

### DIFF
--- a/contracts/BaseCreditPoolStorage.sol
+++ b/contracts/BaseCreditPoolStorage.sol
@@ -14,6 +14,14 @@ contract BaseCreditPoolStorage {
     /// mapping from wallet address to the receivable supplied by this wallet
     mapping(address => BS.ReceivableInfo) internal _receivableInfoMapping;
 
+    CreditPoolConfig internal _creditPoolConfig;
+
+    struct CreditPoolConfig {
+        // Can be used to lock pool functionality for users that haven't interacted with the pool
+        // within a given period of time and need reevaluating
+        uint256 _inactivePeriodInSeconds;
+    }
+
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.

--- a/contracts/BasePool.sol
+++ b/contracts/BasePool.sol
@@ -238,6 +238,10 @@ abstract contract BasePool is BasePoolStorage, OwnableUpgradeable, ILiquidityPro
         _underlyingToken.safeTransfer(_evaluationAgent, amount);
     }
 
+    function bumpLastInteractionTime(address addr) internal {
+        _lastInteractionTime[addr] = uint64(block.timestamp);
+    }
+
     /********************************************/
     //                Settings                  //
     /********************************************/

--- a/contracts/BasePoolStorage.sol
+++ b/contracts/BasePoolStorage.sol
@@ -31,6 +31,9 @@ contract BasePoolStorage {
     // Tracks the amount of liquidity in poolTokens provided to this pool by an address
     mapping(address => uint256) internal _lastDepositTime;
 
+    // Tracks the last meaningful user interaction with the pool (credit line approval, drawdown, payback, etc)
+    mapping(address => uint64) internal _lastInteractionTime;
+
     // whether the pool is ON or OFF
     PoolStatus internal _status;
 

--- a/contracts/ReceivableFactoringPool.sol
+++ b/contracts/ReceivableFactoringPool.sol
@@ -53,6 +53,8 @@ contract ReceivableFactoringPool is BaseCreditPool, IReceivable {
         _creditRecordMapping[borrower] = cr;
 
         disperseRemainingFunds(borrower, refundAmount);
+
+        bumpLastInteractionTime(borrower);
     }
 
     /**

--- a/test/BaseCreditPoolTest.js
+++ b/test/BaseCreditPoolTest.js
@@ -235,6 +235,21 @@ describe("Base Credit Pool", function () {
             expect(await poolContract.totalPoolValue()).to.equal(5_006_600);
             expect(await testTokenContract.balanceOf(poolContract.address)).to.equal(4_011_000);
         });
+
+        it("Rejects borrows after inactivity period has been exceeded", async function () {
+            await poolContract.connect(evaluationAgent).approveCredit(borrower.address);
+            expect(await poolContract.isApproved(borrower.address)).to.equal(true);
+
+            expect(await poolContract.getApprovalStatusForBorrower(borrower.address)).to.equal(
+                true
+            );
+
+            await ethers.provider.send("evm_increaseTime", [4_000_000]);
+
+            await expect(poolContract.connect(borrower).drawdown(1_000_000)).to.be.revertedWith(
+                "USER_REEVALUATION_REQUIRED"
+            );
+        });
     });
 
     // In "Payback".beforeEach(), make sure there is a loan funded.

--- a/test/BaseTest.js
+++ b/test/BaseTest.js
@@ -82,6 +82,7 @@ async function deployAndSetupPool(
     await poolContract.connect(poolOwner).setPoolOwnerRewardsAndLiquidity(625, 10);
     await poolContract.connect(poolOwner).setEvaluationAgent(evaluationAgent.address);
     await poolContract.connect(poolOwner).setEARewardsAndLiquidity(1875, 10);
+    await poolContract.connect(poolOwner).setInactivePeriod(3_000_000);
 
     await testTokenContract.connect(poolOwner).approve(poolContract.address, 1_000_000);
     await poolContract.connect(poolOwner).makeInitialDeposit(1_000_000);

--- a/test/CreditLineIntegrationTest.js
+++ b/test/CreditLineIntegrationTest.js
@@ -72,6 +72,8 @@ describe("Credit Line Integration Test", async function () {
 
         await feeManagerContract.connect(poolOwner).setFees(10, 100, 20, 500);
         await feeManagerContract.connect(poolOwner).setMinPrincipalRateInBps(500);
+
+        await poolContract.connect(poolOwner).setInactivePeriod(10_000_000);
     });
 
     it("Day 0: Initial drawdown", async function () {


### PR DESCRIPTION
- Created a new credit pool config struct and stored an inactivity period setting in there as the first variable (adds around ~0.8kb to contract size unfortunately)
- Bump interaction time on drawdown, payback, and credit line changes. Require credit line reevaluation if the last user interaction was longer than the inactivity period.