### PR TITLE
Introduce EvaluationAgentNFT

### DIFF
--- a/contracts/BaseCreditPool.sol
+++ b/contracts/BaseCreditPool.sol
@@ -537,5 +537,6 @@ contract BaseCreditPool is BasePool, BaseCreditPoolStorage, ICredit, IERC721Rece
 
     function onlyEvaluationAgent() internal view {
         require(msg.sender == _evaluationAgent, "APPROVER_REQUIRED");
+        // require(msg.sender == HumaConfig(_humaConfig).eaServiceAccount(), "APPROVER_REQUIRED");
     }
 }

--- a/contracts/BasePoolStorage.sol
+++ b/contracts/BasePoolStorage.sol
@@ -41,6 +41,8 @@ contract BasePoolStorage {
 
     AccruedIncome internal _accuredIncome;
 
+    uint256 internal _evaluationAgentId;
+
     struct AccruedIncome {
         uint256 _protocolIncome;
         uint256 _poolOwnerIncome;

--- a/contracts/EvaluationAgentNFT.sol
+++ b/contracts/EvaluationAgentNFT.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+
+contract EvaluationAgentNFT is ERC721URIStorage, Ownable {
+    using Counters for Counters.Counter;
+    Counters.Counter private _tokenIds;
+
+    event Mint(address recipient, string tokenURI);
+    event TokenGenerated(uint256 tokenId);
+    event SetURI(uint256 tokenId, string tokenURI);
+
+    constructor() ERC721("EvaluationAgentNFT", "EANFT") {}
+
+    function mint(address recipient, string memory tokenURI) external returns (uint256) {
+        emit Mint(recipient, tokenURI);
+        _tokenIds.increment();
+
+        uint256 newItemId = _tokenIds.current();
+        _mint(recipient, newItemId);
+        _setTokenURI(newItemId, tokenURI);
+
+        emit TokenGenerated(newItemId);
+        return newItemId;
+    }
+
+    function burn(uint256 tokenId) external returns (uint256) {
+        _burn(tokenId);
+        return tokenId;
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override {
+        // Internally disable transfer by doing nothing.
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override {
+        // Internally disable transfer by doing nothing.
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) public virtual override {
+        // Internally disable transfer by doing nothing.
+    }
+
+    function setTokenURI(uint256 tokenId, string memory uri) external {
+        emit SetURI(tokenId, uri);
+        _setTokenURI(tokenId, uri);
+    }
+}

--- a/contracts/HumaConfig.sol
+++ b/contracts/HumaConfig.sol
@@ -38,6 +38,11 @@ contract HumaConfig is Ownable {
     /// humaTreasury is the protocol treasury
     address public humaTreasury;
 
+    /// address of EvaluationAgentNFT contract
+    address public eaNFTContractAddress;
+
+    error zeroAddress();
+
     /// pausers can pause the pool.
     mapping(address => bool) private pausers;
 
@@ -209,6 +214,11 @@ contract HumaConfig is Ownable {
         poolAdmins[_poolAdmin] = false;
 
         emit PoolAdminRemoved(_poolAdmin, owner());
+    }
+
+    function addEANFTContractAddress(address contractAddress) external onlyOwner {
+        require(contractAddress != address(0), "EA_NFT_CONTRACT_ADDRESS_ZERO");
+        eaNFTContractAddress = contractAddress;
     }
 
     /**

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 interface IPool {
     function setPoolName(string memory newName) external;
 
-    function setEvaluationAgent(address agent) external;
+    function setEvaluationAgent(uint256 eaId, address agent) external;
 
     function disablePool() external;
 
@@ -58,7 +58,8 @@ interface IPool {
             uint256 liquiditycap,
             string memory name,
             string memory symbol,
-            uint8 decimal
+            uint8 decimal,
+            uint256 evaluationAgentId
         );
 
     function totalPoolValue() external view returns (uint256);

--- a/test/BaseTest.js
+++ b/test/BaseTest.js
@@ -80,7 +80,7 @@ async function deployAndSetupPool(
     // Config rewards and requirements for poolOwner and EA, make initial deposit, and enable pool
     await poolContract.connect(poolOwner).setPoolLiquidityCap(1_000_000_000);
     await poolContract.connect(poolOwner).setPoolOwnerRewardsAndLiquidity(625, 10);
-    await poolContract.connect(poolOwner).setEvaluationAgent(evaluationAgent.address);
+    await poolContract.connect(poolOwner).setEvaluationAgent(12345, evaluationAgent.address);
     await poolContract.connect(poolOwner).setEARewardsAndLiquidity(1875, 10);
 
     await testTokenContract.connect(poolOwner).approve(poolContract.address, 1_000_000);

--- a/test/InvoiceFactoringTest.js
+++ b/test/InvoiceFactoringTest.js
@@ -108,7 +108,7 @@ describe("Huma Invoice Financing", function () {
         expect(await invoiceContract.lastDepositTime(owner.address)).to.not.equal(0);
         expect(await testTokenContract.balanceOf(invoiceContract.address)).to.equal(100);
 
-        await invoiceContract.setEvaluationAgent(evaluationAgent.address);
+        await invoiceContract.setEvaluationAgent(12345, evaluationAgent.address);
 
         await invoiceContract.connect(owner).setAPR(0); //bps
         await invoiceContract.setMaxCreditLine(1000);

--- a/test/UpgradabilityTest.js
+++ b/test/UpgradabilityTest.js
@@ -77,7 +77,7 @@ describe("Upgradability Test", function () {
         await testTokenContract.approve(poolContract.address, 100);
 
         await poolContract.setMaxCreditLine(1000);
-        await poolContract.setEvaluationAgent(evaluationAgent.address);
+        await poolContract.setEvaluationAgent(12345, evaluationAgent.address);
         await poolContract.enablePool();
     });
 


### PR DESCRIPTION
Changes in this PR:
1. Introduced EvaluationAgentNFT contract
2. Wired EAId into the system
3. Changed getPoolSummary() to include EAId.

Limitation in this PR:
1. EAId is hardcoded in the script. 

Next: 
1. Change deploy sequence to deploy EvaluationAgentNFT, call mint() to get EAId first, set EAId properly throughout. 
2. Introduce eaServiceAccount