### PR TITLE
Expose isDefaultReady()

### DIFF
--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -9,4 +9,6 @@ contract Errors {
     error creditLineExceeded();
     error creditLineAlreadyExists();
     error greaterThanMaxCreditLine();
+    error zeroAddressProvided();
+    error defaultTriggeredTooEarly();
 }

--- a/contracts/HumaConfig.sol
+++ b/contracts/HumaConfig.sol
@@ -41,8 +41,6 @@ contract HumaConfig is Ownable {
     /// address of EvaluationAgentNFT contract
     address public eaNFTContractAddress;
 
-    error zeroAddress();
-
     /// pausers can pause the pool.
     mapping(address => bool) private pausers;
 

--- a/test/BaseCreditPoolTest.js
+++ b/test/BaseCreditPoolTest.js
@@ -373,7 +373,7 @@ describe("Base Credit Pool", function () {
             await poolContract.updateDueInfo(borrower.address, true);
             let creditInfo = await poolContract.getCreditInformation(borrower.address);
             await expect(poolContract.triggerDefault(borrower.address)).to.be.revertedWith(
-                "DEFAULT_TRIGGERED_TOO_EARLY"
+                "defaultTriggeredTooEarly()"
             );
 
             expect(creditInfo.unbilledPrincipal).to.equal(1_010_002);
@@ -389,7 +389,7 @@ describe("Base Credit Pool", function () {
             await poolContract.updateDueInfo(borrower.address, true);
             creditInfo = await poolContract.getCreditInformation(borrower.address);
             await expect(poolContract.triggerDefault(borrower.address)).to.be.revertedWith(
-                "DEFAULT_TRIGGERED_TOO_EARLY"
+                "defaultTriggeredTooEarly()"
             );
 
             expect(creditInfo.unbilledPrincipal).to.equal(1_032_204);

--- a/test/InvoiceFactoringTest.js
+++ b/test/InvoiceFactoringTest.js
@@ -481,7 +481,7 @@ describe("Invoice Factoring", function () {
         describe("Default flow", async function () {
             it("Writeoff less than pool value", async function () {
                 await expect(invoiceContract.triggerDefault(borrower.address)).to.be.revertedWith(
-                    "DEFAULT_TRIGGERED_TOO_EARLY"
+                    "defaultTriggeredTooEarly()"
                 );
                 // post withdraw
                 expect(await hdtContract.withdrawableFundsOf(owner.address)).to.equal(102);
@@ -500,7 +500,7 @@ describe("Invoice Factoring", function () {
                 await invoiceContract.updateDueInfo(borrower.address, true);
 
                 await expect(invoiceContract.triggerDefault(borrower.address)).to.be.revertedWith(
-                    "DEFAULT_TRIGGERED_TOO_EARLY"
+                    "defaultTriggeredTooEarly()"
                 );
                 expect(await hdtContract.withdrawableFundsOf(owner.address)).to.equal(105);
                 expect(await hdtContract.withdrawableFundsOf(lender.address)).to.equal(420);
@@ -515,7 +515,7 @@ describe("Invoice Factoring", function () {
                 await invoiceContract.updateDueInfo(borrower.address, true);
 
                 await expect(invoiceContract.triggerDefault(borrower.address)).to.be.revertedWith(
-                    "DEFAULT_TRIGGERED_TOO_EARLY"
+                    "defaultTriggeredTooEarly()"
                 );
                 expect(await hdtContract.withdrawableFundsOf(owner.address)).to.equal(109);
                 expect(await hdtContract.withdrawableFundsOf(lender.address)).to.equal(432);
@@ -552,12 +552,12 @@ describe("Invoice Factoring", function () {
             });
             it("Writeoff more than pool value", async function () {
                 await expect(invoiceContract.triggerDefault(borrower.address)).to.be.revertedWith(
-                    "DEFAULT_TRIGGERED_TOO_EARLY"
+                    "defaultTriggeredTooEarly()"
                 );
 
                 advanceClock(60);
                 await expect(invoiceContract.triggerDefault(borrower.address)).to.be.revertedWith(
-                    "DEFAULT_TRIGGERED_TOO_EARLY"
+                    "defaultTriggeredTooEarly()"
                 );
 
                 advanceClock(60);


### PR DESCRIPTION
Provide a view function isDefaultReady() to return if the account is ready to be defaulted.  

This function should only be defined in ICredit so that the client can use ICredit instead of BaseCreditPool to call this function and other functions such as isLate(). We will do the interface definition cleanup in one batch so that the client only needs to make change once. 