### PR TITLE
Fix a bug in getPoolSummary and expanded tests

### DIFF
--- a/contracts/BasePool.sol
+++ b/contracts/BasePool.sol
@@ -438,7 +438,7 @@ abstract contract BasePool is BasePoolStorage, OwnableUpgradeable, ILiquidityPro
             address eaNFTAddress
         )
     {
-        IERC20Metadata erc20Contract = IERC20Metadata(address(_poolToken));
+        IERC20Metadata erc20Contract = IERC20Metadata(address(_underlyingToken));
         return (
             address(_underlyingToken),
             _poolConfig._poolAprInBps,

--- a/test/BasePoolTest.js
+++ b/test/BasePoolTest.js
@@ -98,10 +98,15 @@ describe("Base Pool - LP and Admin functions", function () {
         });
 
         it("Should have the right liquidity token and interest", async function () {
-            var [token, interest] = await poolContract.getPoolSummary();
+            let summary = await poolContract.getPoolSummary();
 
-            expect(token).to.equal(testTokenContract.address);
-            expect(interest).to.equal(1217);
+            expect(summary.token).to.equal(testTokenContract.address);
+            expect(summary.apr).to.equal(1217);
+            expect(summary.name).to.equal("TestToken");
+            expect(summary.symbol).to.equal("USDC");
+            expect(summary.decimals).to.equal(6);
+            expect(summary.evaluationAgentId).equal(1);
+            expect(summary.eaNFTAddress).equal(eaNFTContract.address);
         });
 
         it("Should be able to set min and max credit size", async function () {


### PR DESCRIPTION
Now it returns the name, symbol, and decimals of the underlying token instead of the HDT

This change actually saves about 0.24k contract size. 