### PR TITLE
Update linter_ci_js_test.yml

### DIFF
--- a/.github/workflows/linter_ci_js_test.yml
+++ b/.github/workflows/linter_ci_js_test.yml
@@ -17,5 +17,3 @@ jobs:
         run: yarn lint-solidity
       - name: run tests
         run: yarn test
-      - name: deploy test
-        run: yarn deploy --network hardhat


### PR DESCRIPTION
We've removed the deploy script since nobody maintains it. Best would be to test the deploy-goerli.js script in this workflow, but just doing this to unblock.