### PR TITLE
Add  refreshAccount() to make updateDueInfo() internal

### DIFF
--- a/contracts/BaseCreditPool.sol
+++ b/contracts/BaseCreditPool.sol
@@ -396,6 +396,11 @@ contract BaseCreditPool is BasePool, BaseCreditPoolStorage, ICredit, IERC721Rece
         emit PaymentMade(borrower, amountToCollect, msg.sender);
     }
 
+    function refreshAccount(address borrower) external returns (BS.CreditRecord memory cr) {
+        if (isDefaultReady(borrower)) return updateDueInfo(borrower, false);
+        else return updateDueInfo(borrower, true);
+    }
+
     /**
      * @notice updates CreditRecord for `_borrower` using the most up to date information.
      * @dev this is used in both makePayment() and drawdown() to bring the account current
@@ -403,7 +408,7 @@ contract BaseCreditPool is BasePool, BaseCreditPoolStorage, ICredit, IERC721Rece
      * updates the record in creditRecordMapping for `_borrower`
      */
     function updateDueInfo(address borrower, bool distributeChargesForLastCycle)
-        public
+        internal
         virtual
         returns (BS.CreditRecord memory cr)
     {

--- a/test/BaseCreditPoolTest.js
+++ b/test/BaseCreditPoolTest.js
@@ -410,7 +410,7 @@ describe("Base Credit Pool", function () {
             await poolContract.connect(eaServiceAccount).approveCredit(borrower.address);
             await poolContract.connect(borrower).drawdown(1_000_000);
             await expect(
-                poolContract.connect(pdsServiceAccount).updateDueInfo(borrower.address, true)
+                poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address)
             ).to.not.emit(poolContract, "BillRefreshed");
         });
 
@@ -429,9 +429,7 @@ describe("Base Credit Pool", function () {
 
             let expectedDueDate = +previousDueDate + 2592000;
 
-            await expect(
-                poolContract.connect(pdsServiceAccount).updateDueInfo(borrower.address, true)
-            )
+            await expect(poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address))
                 .to.emit(poolContract, "BillRefreshed")
                 .withArgs(borrower.address, expectedDueDate, pdsServiceAccount.address);
         });
@@ -528,7 +526,7 @@ describe("Base Credit Pool", function () {
             // Period 1: Late for payment
             advanceClock(30);
 
-            await poolContract.updateDueInfo(borrower.address, true);
+            await poolContract.refreshAccount(borrower.address);
             let creditInfo = await poolContract.getCreditInformation(borrower.address);
             await expect(poolContract.triggerDefault(borrower.address)).to.be.revertedWith(
                 "defaultTriggeredTooEarly()"
@@ -544,7 +542,7 @@ describe("Base Credit Pool", function () {
             //Period 2: Two periods lates
             advanceClock(30);
 
-            await poolContract.updateDueInfo(borrower.address, true);
+            await poolContract.refreshAccount(borrower.address);
             creditInfo = await poolContract.getCreditInformation(borrower.address);
             await expect(poolContract.triggerDefault(borrower.address)).to.be.revertedWith(
                 "defaultTriggeredTooEarly()"
@@ -603,9 +601,9 @@ describe("Base Credit Pool", function () {
 
             // Period 1: Late for payment, trigger default. The same setup as the "default flow" test.
             advanceClock(30);
-            await poolContract.updateDueInfo(borrower.address, true);
+            await poolContract.refreshAccount(borrower.address);
             advanceClock(30);
-            await poolContract.updateDueInfo(borrower.address, true);
+            await poolContract.refreshAccount(borrower.address);
             advanceClock(30);
 
             dueDate += 2592000 * 3;

--- a/test/InvoiceFactoringTest.js
+++ b/test/InvoiceFactoringTest.js
@@ -595,7 +595,7 @@ describe("Invoice Factoring", function () {
                 // pay period 1
                 advanceClock(30);
                 await ethers.provider.send("evm_mine", []);
-                await invoiceContract.updateDueInfo(borrower.address, true);
+                await invoiceContract.refreshAccount(borrower.address);
 
                 await expect(invoiceContract.triggerDefault(borrower.address)).to.be.revertedWith(
                     "defaultTriggeredTooEarly()"
@@ -610,7 +610,7 @@ describe("Invoice Factoring", function () {
 
                 // pay period 2
                 advanceClock(30);
-                await invoiceContract.updateDueInfo(borrower.address, true);
+                await invoiceContract.refreshAccount(borrower.address);
 
                 await expect(invoiceContract.triggerDefault(borrower.address)).to.be.revertedWith(
                     "defaultTriggeredTooEarly()"


### PR DESCRIPTION
Previously, updateDueInfo() is open to external. The caller has opportunity to specify a flag to indicate whether the income for the final bill should be booked and distributed. This is a hazard since people can call the function with a wrong parameter.

Changed updateDueInfo() to internal and added refreshAccount(), which anyone can call many times without causing harm. Within the function, if the account is default ready, it will call updateDueInfo() with the flag to skip the final bill. 