### PR TITLE
Change periods from days to seconds

### DIFF
--- a/contracts/BaseFeeManager.sol
+++ b/contracts/BaseFeeManager.sol
@@ -19,7 +19,6 @@ contract BaseFeeManager is IFeeManager, Ownable {
     uint256 private constant HUNDRED_PERCENT_IN_BPS = 10000;
     // Divider to get monthly interest rate from APR BPS. 10000 * 12
     uint256 private constant SECONDS_IN_A_YEAR = 31536000;
-    uint256 private constant SECONDS_IN_A_DAY = 86400;
 
     /// Part of platform fee, charged when a borrow happens as a flat amount of the pool token
     uint256 public frontLoadingFeeFlat;
@@ -174,10 +173,7 @@ contract BaseFeeManager is IFeeManager, Ownable {
         // Computes how many billing periods have passed. 1+ is needed since Solidity always
         // round to zero. When it is exactly at a billing cycle, it is desirable to 1+ as well
         if (_cr.dueDate > 0) {
-            periodsPassed =
-                1 +
-                (block.timestamp - _cr.dueDate) /
-                (_crStatic.intervalInDays * SECONDS_IN_A_DAY);
+            periodsPassed = 1 + (block.timestamp - _cr.dueDate) / _crStatic.intervalInSeconds;
         } else {
             periodsPassed = 1;
         }
@@ -199,7 +195,7 @@ contract BaseFeeManager is IFeeManager, Ownable {
             // step 1. late fee calculation
             if (_cr.totalDue > 0)
                 fees = calcLateFee(
-                    _cr.dueDate + i * _crStatic.intervalInDays * SECONDS_IN_A_DAY,
+                    _cr.dueDate + i * _crStatic.intervalInSeconds,
                     _cr.totalDue,
                     _cr.unbilledPrincipal + _cr.totalDue
                 );
@@ -212,10 +208,7 @@ contract BaseFeeManager is IFeeManager, Ownable {
 
             // step 4. computer interest
             interest =
-                (_cr.unbilledPrincipal *
-                    _crStatic.aprInBps *
-                    _crStatic.intervalInDays *
-                    SECONDS_IN_A_DAY) /
+                (_cr.unbilledPrincipal * _crStatic.aprInBps * _crStatic.intervalInSeconds) /
                 SECONDS_IN_A_YEAR /
                 HUNDRED_PERCENT_IN_BPS;
 

--- a/contracts/BasePoolStorage.sol
+++ b/contracts/BasePoolStorage.sol
@@ -8,7 +8,6 @@ import "./BaseFeeManager.sol";
 
 contract BasePoolStorage {
     uint256 internal constant HUNDRED_PERCENT_IN_BPS = 10000;
-    uint256 internal constant SECONDS_IN_A_DAY = 86400;
 
     enum PoolStatus {
         Off,

--- a/contracts/ReceivableFactoringPool.sol
+++ b/contracts/ReceivableFactoringPool.sol
@@ -31,7 +31,7 @@ contract ReceivableFactoringPool is BaseCreditPool, IReceivable {
      * @param receivableAsset the receivable asset used for this credit
      * @param receivableParam additional parameter of the receivable asset, e.g. NFT tokenid
      * @param receivableAmount amount of the receivable asset
-     * @param intervalInDays time interval for each payback in units of days
+     * @param intervalInSeconds time interval for each payback in units of days
      * @param remainingPeriods the number of pay periods for this credit
      * @dev Only Evaluation Agents for this contract can call this function.
      */
@@ -41,7 +41,7 @@ contract ReceivableFactoringPool is BaseCreditPool, IReceivable {
         address receivableAsset,
         uint256 receivableParam,
         uint256 receivableAmount,
-        uint256 intervalInDays,
+        uint256 intervalInSeconds,
         uint256 remainingPeriods
     ) external virtual override {
         onlyEAServiceAccount();
@@ -62,7 +62,7 @@ contract ReceivableFactoringPool is BaseCreditPool, IReceivable {
             borrower,
             creditLimit,
             _poolConfig.poolAprInBps(),
-            intervalInDays,
+            intervalInSeconds,
             remainingPeriods,
             true
         );

--- a/contracts/interfaces/ICredit.sol
+++ b/contracts/interfaces/ICredit.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 interface ICredit {
     function requestCredit(
         uint256 _borrowAmount,
-        uint256 _intervalInDays,
+        uint256 _intervalInSeconds,
         uint256 _numOfPayments
     ) external;
 

--- a/contracts/interfaces/IReceivable.sol
+++ b/contracts/interfaces/IReceivable.sol
@@ -11,7 +11,7 @@ interface IReceivable {
      * @param _receivableAsset the receivable asset used for this credit
      * @param _receivableParam additional parameter of the receivable asset, e.g. NFT tokenid
      * @param _receivableAmount amount of the receivable asset
-     * @param _intervalInDays time interval for each payback in units of days
+     * @param _intervalInSeconds time interval for each payback in units of days
      * @param _remainingPeriods the number of pay periods for this credit
      */
     function recordApprovedCredit(
@@ -20,7 +20,7 @@ interface IReceivable {
         address _receivableAsset,
         uint256 _receivableAmount,
         uint256 _receivableParam,
-        uint256 _intervalInDays,
+        uint256 _intervalInSeconds,
         uint256 _remainingPeriods
     ) external;
 

--- a/contracts/libraries/BaseStructs.sol
+++ b/contracts/libraries/BaseStructs.sol
@@ -26,7 +26,7 @@ library BaseStructs {
     struct CreditRecordStatic {
         uint96 creditLimit; // the limit of the credit line
         uint16 aprInBps; // annual percentage rate in basis points, 3.75% is represented as 375
-        uint16 intervalInDays; // # of days in one billing period
+        uint32 intervalInSeconds; // # of seconds in one billing period
         uint96 defaultAmount; // the amount that has been defaulted.
     }
 
@@ -62,7 +62,7 @@ library BaseStructs {
     //     console.log("cr.missedPeriods=", uint256(cr.missedPeriods));
     //     console.log("cr.remainingPeriods=", uint256(cr.remainingPeriods));
     //     console.log("cr.apr_in_bps=", uint256(cr.aprInBps));
-    //     console.log("cr.intervalInDays=", uint256(cr.intervalInDays));
+    //     console.log("cr.intervalInSeconds=", uint256(cr.intervalInSeconds));
     //     console.log("cr.state=", uint256(cr.state));
     // }
 }

--- a/test/BaseFeeManagerTest.js
+++ b/test/BaseFeeManagerTest.js
@@ -140,7 +140,7 @@ describe("Base Fee Manager", function () {
                 false
             );
 
-            await poolContract.connect(borrower).requestCredit(400, 30, 12);
+            await poolContract.connect(borrower).requestCredit(400, 30 * 86400, 12);
             await poolContract.connect(eaServiceAccount).approveCredit(borrower.address);
             await testTokenContract.connect(lender).approve(poolContract.address, 300);
             await poolContract.connect(borrower).drawdown(400);
@@ -215,7 +215,7 @@ describe("Base Fee Manager", function () {
             await feeManagerContract.connect(poolOwner).setMinPrincipalRateInBps(500);
 
             // Create a borrowing record
-            await poolContract.connect(borrower).requestCredit(5000, 30, 12);
+            await poolContract.connect(borrower).requestCredit(5000, 30 * 86400, 12);
             await poolContract.connect(eaServiceAccount).approveCredit(borrower.address);
             await testTokenContract.connect(poolOwner).approve(poolContract.address, 4000);
             await poolContract.connect(borrower).drawdown(4000);
@@ -285,7 +285,7 @@ describe("Base Fee Manager", function () {
             );
 
             await feeManagerContract.connect(poolOwner).setFees(10, 100, 20, 500, 10);
-            await poolContract.connect(borrower).requestCredit(400, 30, 12);
+            await poolContract.connect(borrower).requestCredit(400, 30 * 86400, 12);
             await poolContract.connect(eaServiceAccount).approveCredit(borrower.address);
             await testTokenContract.connect(lender).approve(poolContract.address, 300);
             await poolContract.connect(borrower).drawdown(400);
@@ -360,7 +360,7 @@ describe("Base Fee Manager", function () {
             await feeManagerContract.connect(poolOwner).setMinPrincipalRateInBps(500);
 
             // Create a borrowing record
-            await poolContract.connect(borrower).requestCredit(5000, 30, 12);
+            await poolContract.connect(borrower).requestCredit(5000, 30 * 86400, 12);
             await poolContract.connect(eaServiceAccount).approveCredit(borrower.address);
             await testTokenContract.connect(poolOwner).approve(poolContract.address, 4000);
             await poolContract.connect(borrower).drawdown(4000);

--- a/test/BaseTest.js
+++ b/test/BaseTest.js
@@ -178,7 +178,7 @@ async function checkRecord(r, rs, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, 
     if (v7 != "SKIP") expect(r.missedPeriods).to.equal(v7);
     if (v8 != "SKIP") expect(r.remainingPeriods).to.equal(v8);
     if (v9 != "SKIP") expect(rs.aprInBps).to.equal(v9);
-    if (v10 != "SKIP") expect(rs.intervalInDays).to.equal(v10);
+    if (v10 != "SKIP") expect(rs.intervalInSeconds).to.equal(v10);
     if (v11 != "SKIP") expect(r.state).to.equal(v11);
     if (v12 != "SKIP") expect(rs.defaultAmount).to.equal(v12);
 }

--- a/test/CreditLineIntegrationTest.js
+++ b/test/CreditLineIntegrationTest.js
@@ -81,15 +81,15 @@ describe("Credit Line Integration Test", async function () {
 
     it("Day 0: Initial drawdown", async function () {
         // Establish credit line
-        await poolContract.connect(borrower).requestCredit(5000, 30, 12);
+        await poolContract.connect(borrower).requestCredit(5000, 30*86400, 12);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 0, "SKIP", 0, 0, 0, 0, 12, 1217, 30, 1, 0);
+        checkRecord(record, recordStatic, 5000, 0, "SKIP", 0, 0, 0, 0, 12, 1217, 30*86400, 1, 0);
 
         await poolContract.connect(eaServiceAccount).approveCredit(borrower.address);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 0, "SKIP", 0, 0, 0, 0, 12, 1217, 30, 2, 0);
+        checkRecord(record, recordStatic, 5000, 0, "SKIP", 0, 0, 0, 0, 12, 1217, 30*86400, 2, 0);
 
         let blockNumBefore = await ethers.provider.getBlockNumber();
         let blockBefore = await ethers.provider.getBlock(blockNumBefore);
@@ -99,7 +99,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).drawdown(2000);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 1900, dueDate, 0, 120, 20, 0, 11, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 1900, dueDate, 0, 120, 20, 0, 11, 1217, 30*86400, 3, 0);
 
         let r = await feeManagerContract.getDueInfo(record, recordStatic);
         checkResult(r, 0, 20, 120, 1900, 0);
@@ -111,7 +111,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).drawdown(2000);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 3900, dueDate, 10, 120, 20, 0, 11, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 3900, dueDate, 10, 120, 20, 0, 11, 1217, 30*86400, 3, 0);
 
         let r = await feeManagerContract.getDueInfo(record, recordStatic);
         checkResult(r, 0, 20, 120, 3900, 0);
@@ -124,7 +124,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).makePayment(borrower.address, 120);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 3900, dueDate, 10, 0, 0, 0, 11, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 3900, dueDate, 10, 0, 0, 0, 11, 1217, 30*86400, 3, 0);
 
         let r = await feeManagerContract.getDueInfo(record, recordStatic);
         checkResult(r, 0, 0, 0, 3900, 0);
@@ -145,7 +145,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).makePayment(borrower.address, 244);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 3705, dueDate, -1, 0, 0, 0, 10, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 3705, dueDate, -1, 0, 0, 0, 10, 1217, 30*86400, 3, 0);
     });
 
     it("Day 60: 3rd statement", async function () {
@@ -164,7 +164,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).makePayment(borrower.address, 100);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 3520, dueDate, 0, 121, 0, 0, 9, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 3520, dueDate, 0, 121, 0, 0, 9, 1217, 30*86400, 3, 0);
     });
 
     it("Day 90: 4th statement (late due to partial payment", async function () {
@@ -183,7 +183,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).makePayment(borrower.address, 100);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 3459, dueDate, 0, 320, 138, 1, 8, 1217, 30, 4, 0);
+        checkRecord(record, recordStatic, 5000, 3459, dueDate, 0, 320, 138, 1, 8, 1217, 30*86400, 4, 0);
     });
 
     it("Day 105: Over payment", async function () {
@@ -193,7 +193,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).makePayment(borrower.address, 400);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 3379, dueDate, -1, 0, 0, 0, 8, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 3379, dueDate, -1, 0, 0, 0, 8, 1217, 30*86400, 3, 0);
     });
 
     it("Day 110: Extra principal payment)", async function () {
@@ -203,7 +203,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).makePayment(borrower.address, 400);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 2979, dueDate, -2, 0, 0, 0, 8, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 2979, dueDate, -2, 0, 0, 0, 8, 1217, 30*86400, 3, 0);
     });
 
     it("Day 120: 5th statement", async function () {
@@ -253,7 +253,7 @@ describe("Credit Line Integration Test", async function () {
 
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 0, dueDate, 0, 0, 0, 0, 4, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 0, dueDate, 0, 0, 0, 0, 4, 1217, 30*86400, 3, 0);
     });
 
     // This happens slightly after day 300. Thus mis the cycle. No bill is generated until day 330
@@ -264,7 +264,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).drawdown(4000);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 4000, dueDate, 40, 0, 0, 0, 1, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 4000, dueDate, 40, 0, 0, 0, 1, 1217, 30*86400, 3, 0);
     });
 
     it("Day 330: new bill", async function () {
@@ -281,7 +281,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(eaServiceAccount).extendCreditLineDuration(borrower.address, 2);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 0, dueDate, 0, 4080, 80, 0, 2, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 0, dueDate, 0, 4080, 80, 0, 2, 1217, 30*86400, 3, 0);
     });
 
     it("Day 350: Partial pay, below required interest", async function () {
@@ -290,7 +290,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).makePayment(borrower.address, 20);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 0, dueDate, 0, 4060, 60, 0, 2, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 0, dueDate, 0, 4060, 60, 0, 2, 1217, 30*86400, 3, 0);
     });
 
     it("Day 352: Drawdown blocked due to over limit", async function () {
@@ -305,7 +305,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).drawdown(1000);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 1000, dueDate, 1, 4060, 60, 0, 2, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 1000, dueDate, 1, 4060, 60, 0, 2, 1217, 30*86400, 3, 0);
     });
 
     it("Day 358: Pay with amountDue", async function () {
@@ -314,7 +314,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).makePayment(borrower.address, 4060);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 1000, dueDate, -1, 0, 0, 0, 2, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 1000, dueDate, -1, 0, 0, 0, 2, 1217, 30*86400, 3, 0);
     });
 
     it("Day 360: normal statement", async function () {
@@ -330,7 +330,7 @@ describe("Credit Line Integration Test", async function () {
         await poolContract.connect(borrower).makePayment(borrower.address, 59);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 950, dueDate, 0, 0, 0, 0, 1, 1217, 30, 3, 0);
+        checkRecord(record, recordStatic, 5000, 950, dueDate, 0, 0, 0, 0, 1, 1217, 30*86400, 3, 0);
     });
 
     it("Day 390: Final statement, all principal due", async function () {
@@ -355,6 +355,6 @@ describe("Credit Line Integration Test", async function () {
             .withArgs(borrower.address, 955, borrower.address);
         record = await poolContract.creditRecordMapping(borrower.address);
         recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(record, recordStatic, 5000, 0, dueDate, 0, 0, 0, 0, 0, 1217, 30, 0, 0);
+        checkRecord(record, recordStatic, 5000, 0, dueDate, 0, 0, 0, 0, 0, 1217, 30*86400, 0, 0);
     });
 });

--- a/test/InvoiceFactoringTest.js
+++ b/test/InvoiceFactoringTest.js
@@ -137,7 +137,7 @@ describe("Invoice Factoring", function () {
                         invoiceNFTContract.address,
                         invoiceNFTTokenId,
                         1_500_000,
-                        30,
+                        30 * 86400,
                         1
                     )
             ).to.be.revertedWith("evaluationAgentServiceAccountRequired()");
@@ -156,7 +156,7 @@ describe("Invoice Factoring", function () {
                         invoiceNFTContract.address,
                         invoiceNFTTokenId,
                         1_500_000,
-                        30,
+                        30 * 86400,
                         1
                     )
             ).to.be.revertedWith("protocolIsPaused()");
@@ -174,7 +174,7 @@ describe("Invoice Factoring", function () {
                         invoiceNFTContract.address,
                         invoiceNFTTokenId,
                         1_500_000,
-                        30,
+                        30 * 86400,
                         1
                     )
             ).to.be.revertedWith("poolIsNotOn()");
@@ -190,7 +190,7 @@ describe("Invoice Factoring", function () {
                         invoiceNFTContract.address,
                         invoiceNFTTokenId,
                         1_500_000,
-                        30,
+                        30 * 86400,
                         1
                     )
             ).to.be.revertedWith("greaterThanMaxCreditLine()");
@@ -209,7 +209,7 @@ describe("Invoice Factoring", function () {
                     invoiceNFTContract.address,
                     invoiceNFTTokenId,
                     1_500_000,
-                    30,
+                    30 * 86400,
                     1
                 );
 
@@ -234,7 +234,7 @@ describe("Invoice Factoring", function () {
                         invoiceNFTContract.address,
                         invoiceNFTTokenId,
                         1_000_000,
-                        30,
+                        30 * 86400,
                         1
                     )
             ).to.be.revertedWith("insufficientReceivableAmount()");
@@ -251,7 +251,7 @@ describe("Invoice Factoring", function () {
                     invoiceNFTContract.address,
                     invoiceNFTTokenId,
                     1_500_000,
-                    30,
+                    30 * 86400,
                     1
                 );
 
@@ -273,7 +273,7 @@ describe("Invoice Factoring", function () {
                     invoiceNFTContract.address,
                     invoiceNFTTokenId,
                     1_500_000,
-                    30,
+                    30 * 86400,
                     1
                 );
         });
@@ -317,12 +317,12 @@ describe("Invoice Factoring", function () {
                     invoiceNFTContract.address,
                     invoiceNFTTokenId,
                     1_500_0000,
-                    30,
+                    30 * 86400,
                     1
                 );
             record = await poolContract.creditRecordMapping(borrower.address);
             recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-            checkRecord(record, recordStatic, 1_000_000, 0, 0, 0, 0, 0, 0, 1, 0, 30, 2, 0);
+            checkRecord(record, recordStatic, 1_000_000, 0, 0, 0, 0, 0, 0, 1, 0, 30 * 86400, 2, 0);
         });
 
         afterEach(async function () {
@@ -369,7 +369,7 @@ describe("Invoice Factoring", function () {
 
             r = await poolContract.creditRecordMapping(borrower.address);
             rs = await poolContract.creditRecordStaticMapping(borrower.address);
-            checkRecord(r, rs, 1_000_000, 0, dueDate, 0, 200_000, 0, 0, 0, 0, 30, 3, 0);
+            checkRecord(r, rs, 1_000_000, 0, dueDate, 0, 200_000, 0, 0, 0, 0, 30 * 86400, 3, 0);
 
             let dueInfo = await feeManagerContract.getDueInfo(r, rs);
             checkResult(dueInfo, 0, 0, 200_000, 0, 0);
@@ -414,7 +414,7 @@ describe("Invoice Factoring", function () {
 
             r = await poolContract.creditRecordMapping(borrower.address);
             rs = await poolContract.creditRecordStaticMapping(borrower.address);
-            checkRecord(r, rs, 1_000_000, 0, dueDate, 0, 1_000_000, 0, 0, 0, 0, 30, 3, 0);
+            checkRecord(r, rs, 1_000_000, 0, dueDate, 0, 1_000_000, 0, 0, 0, 0, 30 * 86400, 3, 0);
 
             let dueInfo = await feeManagerContract.getDueInfo(r, rs);
             checkResult(dueInfo, 0, 0, 1_000_000, 0, 0);
@@ -448,7 +448,7 @@ describe("Invoice Factoring", function () {
                     invoiceNFTContract.address,
                     invoiceNFTTokenId,
                     1_500_000,
-                    30,
+                    30 * 86400,
                     1
                 );
 
@@ -550,7 +550,7 @@ describe("Invoice Factoring", function () {
 
             r = await poolContract.creditRecordMapping(borrower.address);
             rs = await poolContract.creditRecordStaticMapping(borrower.address);
-            checkRecord(r, rs, 1_000_000, 0, dueDate, 0, 0, 0, 0, 0, 0, 30, 0, 0);
+            checkRecord(r, rs, 1_000_000, 0, dueDate, 0, 0, 0, 0, 0, 0, 30 * 86400, 0, 0);
 
             let dueInfo = await feeManagerContract.getDueInfo(r, rs);
             checkResult(dueInfo, 0, 0, 0, 0, 0);


### PR DESCRIPTION
Changed period interval from days to seconds. This is to allow people to be able to test the end-to-end lending experience without waiting for at least a day.  @PlayJok3r This will broke your code that calls recordApprovedCredit(), please convert the parameter for the intervalInSeconds (was intervalInDays) field to seconds. 