### PR TITLE
Allow borrower to reduce credit line

### DIFF
--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -61,4 +61,5 @@ contract Errors {
     error underlyingTokenNotApprovedForHumaProtocol();
 
     error requestedCreditWithZeroDuration();
+    error onlyBorrowerOrEACanReduceCreditLine();
 }

--- a/test/BaseCreditPoolTest.js
+++ b/test/BaseCreditPoolTest.js
@@ -306,7 +306,6 @@ describe("Base Credit Pool", function () {
             expect(await poolContract.isApproved(evaluationAgent.address)).to.equal(false);
 
             let oldBalance = await testTokenContract.balanceOf(borrower.address);
-            console.log(oldBalance);
             await poolContract.connect(borrower).drawdown(borrower.address, 100_000);
 
             // Two streams of income


### PR DESCRIPTION
Previously, only EA can change credit limit. 

The borrower should be allowed to reduce credit line, including bringing it to zero. 