### PR TITLE
Change a way to handle dueDate during first drawdown

### DIFF
--- a/contracts/libraries/BaseStructs.sol
+++ b/contracts/libraries/BaseStructs.sol
@@ -48,21 +48,4 @@ library BaseStructs {
         Delayed,
         Defaulted
     }
-
-    // Please do NOT delete during development stage.
-    // Debugging helper function. Please comment out after finishing debugging.
-    // function printCreditInfo(CreditRecord memory cr) internal view {
-    //     console.log("##### Status of the Credit #####");
-    //     console.log("cr.creditLimit=", uint256(cr.creditLimit));
-    //     console.log("cr.unbilledPrincipal=", uint256(cr.unbilledPrincipal));
-    //     console.log("cr.dueDate=", uint256(cr.dueDate));
-    //     console.logInt(cr.correction);
-    //     console.log("cr.totalDue=", uint256(cr.totalDue));
-    //     console.log("cr.feesAndInterestDue=", uint256(cr.feesAndInterestDue));
-    //     console.log("cr.missedPeriods=", uint256(cr.missedPeriods));
-    //     console.log("cr.remainingPeriods=", uint256(cr.remainingPeriods));
-    //     console.log("cr.apr_in_bps=", uint256(cr.aprInBps));
-    //     console.log("cr.intervalInDays=", uint256(cr.intervalInDays));
-    //     console.log("cr.state=", uint256(cr.state));
-    // }
 }

--- a/test/BaseCreditPoolTest.js
+++ b/test/BaseCreditPoolTest.js
@@ -128,7 +128,7 @@ describe("Base Credit Pool", function () {
             expect(record.state).to.equal(0);
         });
 
-        it("Should note delete a credit line when there is balance due when set credit limit to 0", async function () {
+        it("Should not delete a credit line when there is balance due when set credit limit to 0", async function () {
             let record = await poolContract.creditRecordMapping(borrower.address);
             expect(record.totalDue).to.equal(0);
             expect(record.unbilledPrincipal).to.equal(0);
@@ -300,7 +300,9 @@ describe("Base Credit Pool", function () {
         });
 
         it("Should reject if the borrowing amount is zero", async function () {
-            await poolContract.connect(eaServiceAccount).approveCredit(borrower.address, 1_000_000, 30, 12, 1217);
+            await poolContract
+                .connect(eaServiceAccount)
+                .approveCredit(borrower.address, 1_000_000, 30, 12, 1217);
             await expect(
                 poolContract.connect(borrower).drawdown(borrower.address, 0)
             ).to.be.revertedWith("zeroAmountProvided()");
@@ -411,7 +413,9 @@ describe("Base Credit Pool", function () {
         it("Shall not mark the account as late if there is no drawdown", async function () {
             await poolConfigContract.connect(poolOwner).setCreditApprovalExpiration(5);
             await poolContract.connect(borrower).requestCredit(1_000_000, 30, 12);
-            await poolContract.connect(eaServiceAccount).approveCredit(borrower.address, 1_000_000, 30, 12, 1217);
+            await poolContract
+                .connect(eaServiceAccount)
+                .approveCredit(borrower.address, 1_000_000, 30, 12, 1217);
 
             expect(await poolContract.isLate(borrower.address)).to.equal(false);
 
@@ -421,7 +425,9 @@ describe("Base Credit Pool", function () {
         it("Shall mark the account as late if no payment is received by the dueDate", async function () {
             await poolConfigContract.connect(poolOwner).setCreditApprovalExpiration(5);
             await poolContract.connect(borrower).requestCredit(1_000_000, 30, 12);
-            await poolContract.connect(eaServiceAccount).approveCredit(borrower.address, 1_000_000, 30, 12, 1217);
+            await poolContract
+                .connect(eaServiceAccount)
+                .approveCredit(borrower.address, 1_000_000, 30, 12, 1217);
             expect(await poolContract.isLate(borrower.address)).to.equal(false);
             advanceClock(2);
             await poolContract.connect(borrower).drawdown(borrower.address, 1_000_000);


### PR DESCRIPTION
There was a bug in the dueDate calculation for first drawdown when there is expiration requirement for the first drawdown. It adds one more cycle to existing dueDate, which is the credit approval time plus the credit expiration window. This is incorrect. Overall, dueDate is very confusing in this case. The program now set dueDate to 0 after the eligibility check including first drawdown expiration check, when all existing logic works as before we introduced credit expiration change. 