### PR TITLE
fix: apply 4 security patches to BaseCreditPool

### DIFF
--- a/abi/BaseCreditPool.json
+++ b/abi/BaseCreditPool.json
@@ -11,11 +11,6 @@
   },
   {
     "inputs": [],
-    "name": "creditLineAlreadyExists",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "creditLineExceeded",
     "type": "error"
   },
@@ -92,11 +87,6 @@
   {
     "inputs": [],
     "name": "protocolIsPaused",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "requestedCreditWithZeroDuration",
     "type": "error"
   },
   {

--- a/abi/Errors.json
+++ b/abi/Errors.json
@@ -261,6 +261,11 @@
   },
   {
     "inputs": [],
+    "name": "transferNotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "treasuryFeeHighThanUpperLimit",
     "type": "error"
   },

--- a/abi/HDT.json
+++ b/abi/HDT.json
@@ -11,6 +11,11 @@
   },
   {
     "inputs": [],
+    "name": "transferNotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "zeroAddressProvided",
     "type": "error"
   },

--- a/contracts/BaseCreditPool.sol
+++ b/contracts/BaseCreditPool.sol
@@ -270,7 +270,10 @@ contract BaseCreditPool is BasePool, BaseCreditPoolStorage, ICredit {
         override
         returns (BS.CreditRecord memory cr)
     {
-        if (_creditRecordMapping[borrower].state != BS.CreditState.Defaulted) {
+        if (
+            _creditRecordMapping[borrower].state == BS.CreditState.GoodStanding ||
+            _creditRecordMapping[borrower].state == BS.CreditState.Delayed
+        ) {
             if (isDefaultReady(borrower)) return _updateDueInfo(borrower, false, false);
             else return _updateDueInfo(borrower, false, true);
         }
@@ -287,15 +290,7 @@ contract BaseCreditPool is BasePool, BaseCreditPoolStorage, ICredit {
         uint256 intervalInDays,
         uint256 numOfPayments
     ) external virtual override {
-        // Open access to the borrower. Data validation happens in _initiateCredit()
-        _initiateCredit(
-            msg.sender,
-            creditLimit,
-            _poolConfig.poolAprInBps(),
-            intervalInDays,
-            numOfPayments,
-            false
-        );
+        // disabled - no-op, use approveCredit instead
     }
 
     /**
@@ -306,6 +301,7 @@ contract BaseCreditPool is BasePool, BaseCreditPoolStorage, ICredit {
      */
     function triggerDefault(address borrower) external virtual override returns (uint256 losses) {
         _protocolAndPoolOn();
+        onlyEAServiceAccount();
 
         // check to make sure the default grace period has passed.
         BS.CreditRecord memory cr = _getCreditRecord(borrower);
@@ -854,7 +850,7 @@ contract BaseCreditPool is BasePool, BaseCreditPoolStorage, ICredit {
 
             if (cr.missedPeriods > 0) {
                 if (cr.state != BS.CreditState.Defaulted) cr.state = BS.CreditState.Delayed;
-            } else cr.state = BS.CreditState.GoodStanding;
+            } else if (cr.state == BS.CreditState.Delayed) cr.state = BS.CreditState.GoodStanding;
 
             _setCreditRecord(borrower, cr);
 

--- a/contracts/BaseCreditPool.sol
+++ b/contracts/BaseCreditPool.sol
@@ -270,6 +270,7 @@ contract BaseCreditPool is BasePool, BaseCreditPoolStorage, ICredit {
         override
         returns (BS.CreditRecord memory cr)
     {
+        onlyPDSServiceAccount();
         if (
             _creditRecordMapping[borrower].state == BS.CreditState.GoodStanding ||
             _creditRecordMapping[borrower].state == BS.CreditState.Delayed

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -27,6 +27,7 @@ contract Errors {
     error notPool(); // 0x26d29bbf
     error drawdownFunctionUsedInsteadofDrawdownWithReceivable(); // 0x7e737537
     error notNFTOwner(); // 0x091a5762
+    error transferNotAllowed(); // HDT transfer disabled
 
     // system config
     error defaultGracePeriodLessThanMinAllowed(); // 0xa733ff9c

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -27,7 +27,7 @@ contract Errors {
     error notPool(); // 0x26d29bbf
     error drawdownFunctionUsedInsteadofDrawdownWithReceivable(); // 0x7e737537
     error notNFTOwner(); // 0x091a5762
-    error transferNotAllowed(); // HDT transfer disabled
+    error transferNotAllowed(); // 0x791b2e14
 
     // system config
     error defaultGracePeriodLessThanMinAllowed(); // 0xa733ff9c

--- a/contracts/HDT/HDT.sol
+++ b/contracts/HDT/HDT.sol
@@ -148,4 +148,15 @@ contract HDT is ERC20Upgradeable, OwnableUpgradeable, HDTStorage, IHDT {
         if (msg.sender != address(_pool)) revert Errors.notPool();
         _;
     }
+
+    /**
+     * @notice Disable HDT token transfers. Only mint (from=0) and burn (to=0) are allowed.
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 /* amount */
+    ) internal virtual override {
+        if (from != address(0) && to != address(0)) revert Errors.transferNotAllowed();
+    }
 }

--- a/test/BaseCreditPoolTest.js
+++ b/test/BaseCreditPoolTest.js
@@ -153,7 +153,6 @@ describe("Base Credit Pool", function () {
             expect(record.totalDue).to.equal(0);
             expect(record.unbilledPrincipal).to.equal(0);
 
-            await poolContract.connect(borrower).requestCredit(toToken(4000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(4000), 30, 12, 1217);
@@ -215,112 +214,16 @@ describe("Base Credit Pool", function () {
         });
     });
 
-    // Borrowing tests are grouped into two suites: Borrowing Request and Funding.
-    // In beforeEach() of "Borrowing request", we make sure there is 100 liquidity.
     describe("Borrowing request", function () {
-        afterEach(async function () {
-            if (await humaConfigContract.connect(protocolOwner).paused())
-                await humaConfigContract.connect(protocolOwner).unpause();
-        });
-
-        it("Should reject loan requests while zero period", async function () {
-            await humaConfigContract.connect(poolOwner).pause();
-            await expect(
-                poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 0)
-            ).to.be.revertedWithCustomError(poolContract, "requestedCreditWithZeroDuration");
-        });
-        it("Should reject loan requests while protocol is paused", async function () {
-            await humaConfigContract.connect(poolOwner).pause();
-            await expect(
-                poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12)
-            ).to.be.revertedWithCustomError(poolContract, "protocolIsPaused");
-        });
-
-        it("Shall reject request loan while pool is off", async function () {
-            await poolContract.connect(poolOwner).disablePool();
-            await expect(
-                poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12)
-            ).to.be.revertedWithCustomError(poolContract, "poolIsNotOn");
-        });
-
-        it("Shall reject request loan greater than limit", async function () {
-            await expect(
-                poolContract.connect(borrower).requestCredit(toToken(10_000_001), 30, 12)
-            ).to.be.revertedWithCustomError(poolContract, "greaterThanMaxCreditLine");
-        });
-
-        it("Shall allow loan request", async function () {
-            expect(await testTokenContract.balanceOf(borrower.address)).to.equal(0);
-
-            await poolConfigContract.connect(poolOwner).setAPR(1217);
-
+        it("requestCredit is disabled (no-op)", async function () {
             await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
-
-            const loanInformation = await getCreditInfo(poolContract, borrower.address);
-            expect(loanInformation.creditLimit).to.equal(toToken(1_000_000));
-            expect(loanInformation.intervalInDays).to.equal(30);
-            expect(loanInformation.aprInBps).to.equal(1217);
-            expect(loanInformation.state).to.equal(1);
-        });
-
-        it("Shall allow new request if there is existing loan in Requested state", async function () {
-            await poolContract.connect(borrower).requestCredit(toToken(1_000), 30, 12);
-            await poolContract.connect(borrower).requestCredit(toToken(2_000), 60, 24);
-            const loanInformation = await getCreditInfo(poolContract, borrower.address);
-            expect(loanInformation.creditLimit).to.equal(toToken(2_000));
-            expect(loanInformation.intervalInDays).to.equal(60);
-            expect(loanInformation.aprInBps).to.equal(1217);
-            expect(loanInformation.remainingPeriods).to.equal(24);
-            expect(loanInformation.state).to.equal(1);
-        });
-
-        it("Shall reject loan requests if there is an outstanding loan with outstanding balance", async function () {
-            await poolContract.connect(borrower).requestCredit(toToken(3_000), 30, 12);
-            await poolContract
-                .connect(eaServiceAccount)
-                .approveCredit(borrower.address, toToken(3000), 30, 12, 1217);
-            await poolContract.connect(borrower).drawdown(toToken(2_000));
-
-            await expect(
-                poolContract.connect(borrower).requestCredit(toToken(1_000), 30, 12)
-            ).to.be.revertedWithCustomError(poolContract, "creditLineAlreadyExists");
-        });
-
-        it("Shall allow new request if existing loan has been paid off", async function () {
-            await poolContract.connect(borrower).requestCredit(toToken(3_000), 30, 12);
-            await expect(
-                poolContract.connect(borrower).makePayment(borrower.address, toToken(3_000))
-            ).to.be.revertedWithCustomError(poolContract, "creditLineNotInStateForMakingPayment");
-
-            await poolContract
-                .connect(eaServiceAccount)
-                .approveCredit(borrower.address, toToken(3000), 30, 12, 1217);
-            await expect(
-                poolContract.connect(borrower).makePayment(borrower.address, toToken(3_000))
-            ).to.be.revertedWithCustomError(poolContract, "creditLineNotInStateForMakingPayment");
-
-            await poolContract.connect(borrower).drawdown(toToken(3_000));
-            await testTokenContract.connect(borrower).mint(borrower.address, toToken(2_000));
-            await testTokenContract
-                .connect(borrower)
-                .approve(poolContract.address, toToken(3_100));
-            await poolContract.connect(borrower).makePayment(borrower.address, toToken(3_100));
-            await poolContract.connect(borrower).requestCredit(toToken(4_000), 90, 36);
-            const loanInformation = await getCreditInfo(poolContract, borrower.address);
-            expect(loanInformation.creditLimit).to.equal(toToken(4_000));
-            expect(loanInformation.intervalInDays).to.equal(90);
-            expect(loanInformation.aprInBps).to.equal(1217);
-            expect(loanInformation.remainingPeriods).to.equal(36);
-            expect(loanInformation.state).to.equal(1);
-            expect(loanInformation.totalDue).to.equal(0);
-            expect(loanInformation.feesAndInterestDue).to.equal(0);
-            expect(loanInformation.correction).to.equal(0);
+            const cr = await poolContract.creditRecordMapping(borrower.address);
+            expect(cr.state).to.equal(0); // Deleted - no credit created
         });
     });
 
     describe("Drawdown", function () {
         beforeEach(async function () {
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
         });
 
         it("Should not allow loan funding while protocol is paused", async function () {
@@ -539,7 +442,6 @@ describe("Base Credit Pool", function () {
     describe("IsLate()", function () {
         it("Shall not mark the account as late if there is no drawdown", async function () {
             await poolConfigContract.connect(poolOwner).setCreditApprovalExpiration(5);
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
@@ -551,7 +453,6 @@ describe("Base Credit Pool", function () {
         });
         it("Shall mark the account as late if no payment is received by the dueDate", async function () {
             await poolConfigContract.connect(poolOwner).setCreditApprovalExpiration(5);
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
@@ -567,7 +468,6 @@ describe("Base Credit Pool", function () {
     describe("Credit expiration without a timely first drawdown", function () {
         it("Cannot borrow after credit expiration window", async function () {
             await poolConfigContract.connect(poolOwner).setCreditApprovalExpiration(5);
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
@@ -581,25 +481,23 @@ describe("Base Credit Pool", function () {
 
         it("Can borrow if no credit expiration has been setup for the pool", async function () {
             await poolConfigContract.connect(poolOwner).setCreditApprovalExpiration(0);
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
 
             await advanceClock(6);
 
-            await expect(poolContract.connect(borrower).drawdown(toToken(1_000_000)));
+            await poolContract.connect(borrower).drawdown(toToken(1_000_000));
             let creditInfo = await poolContract.creditRecordMapping(borrower.address);
             expect(creditInfo.remainingPeriods).to.equal(11);
         });
 
         it("Expiration window does not apply after initial drawdown", async function () {
             await poolConfigContract.connect(poolOwner).setCreditApprovalExpiration(5);
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
-            await expect(poolContract.connect(borrower).drawdown(toToken(500_000)));
+            await poolContract.connect(borrower).drawdown(toToken(500_000));
             let creditInfo = await poolContract.creditRecordMapping(borrower.address);
             expect(creditInfo.unbilledPrincipal).to.equal(toToken(500_000));
 
@@ -613,7 +511,6 @@ describe("Base Credit Pool", function () {
 
     describe("Account update by service account", function () {
         it("Shall not emit BillRefreshed event when the bill should not be refreshed", async function () {
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
@@ -624,7 +521,6 @@ describe("Base Credit Pool", function () {
         });
 
         it("Shall emit BillRefreshed event when the bill is refreshed", async function () {
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
@@ -673,7 +569,6 @@ describe("Base Credit Pool", function () {
             expect(accruedIncome.eaIncome).to.equal(6480834246);
         });
         it("BillRefresh when it is default ready should not distribute income", async function () {
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
@@ -724,11 +619,11 @@ describe("Base Credit Pool", function () {
             expect(accruedIncome.eaIncome).to.equal(13342866129);
 
             // trigger default
-            await expect(poolContract.connect(pdsServiceAccount).triggerDefault(borrower.address))
+            await expect(poolContract.connect(eaServiceAccount).triggerDefault(borrower.address))
                 .to.emit(poolContract, "DefaultTriggered")
-                .withArgs(borrower.address, 1077952440866, pdsServiceAccount.address);
+                .withArgs(borrower.address, 1077952440866, eaServiceAccount.address);
 
-            // post-default refreshAccount should do nothing
+            // post-default refreshAccount is no-op (Patch 3: only GoodStanding or Delayed)
             await advanceClock(30);
             await expect(
                 poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address)
@@ -738,13 +633,59 @@ describe("Base Credit Pool", function () {
             expect(accruedIncome.poolOwnerIncome).to.equal(4447622043);
             expect(accruedIncome.eaIncome).to.equal(13342866129);
         });
+
+        it("refreshAccount should be no-op for Approved state", async function () {
+            await poolContract
+                .connect(eaServiceAccount)
+                .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
+
+            // Account is Approved (state=2), no drawdown yet
+            let record = await poolContract.creditRecordMapping(borrower.address);
+            expect(record.state).to.equal(2);
+
+            await advanceClock(31);
+
+            // refreshAccount should be no-op because state is not GoodStanding or Delayed
+            await expect(
+                poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address)
+            ).to.not.emit(poolContract, "BillRefreshed");
+        });
+
+        it("refreshAccount should be no-op for Deleted state", async function () {
+            // borrower has no credit record, state defaults to Deleted (0)
+            let record = await poolContract.creditRecordMapping(borrower.address);
+            expect(record.state).to.equal(0);
+
+            await expect(
+                poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address)
+            ).to.not.emit(poolContract, "BillRefreshed");
+        });
+
+        it("refreshAccount should be no-op for Defaulted state", async function () {
+            await poolContract
+                .connect(eaServiceAccount)
+                .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
+            await poolContract.connect(borrower).drawdown(toToken(1_000_000));
+
+            // Advance to default-ready
+            await advanceClock(100);
+            await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
+            await poolContract.connect(eaServiceAccount).triggerDefault(borrower.address);
+
+            let record = await poolContract.creditRecordMapping(borrower.address);
+            expect(record.state).to.equal(5); // Defaulted
+
+            await advanceClock(31);
+            await expect(
+                poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address)
+            ).to.not.emit(poolContract, "BillRefreshed");
+        });
     });
 
     // In "Payback".beforeEach(), make sure there is a loan funded.
     describe("Payback", function () {
         beforeEach(async function () {
             await poolConfigContract.connect(poolOwner).setAPR(1217);
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
 
             await poolContract
                 .connect(eaServiceAccount)
@@ -843,7 +784,6 @@ describe("Base Credit Pool", function () {
             let lenderBalance = await testTokenContract.balanceOf(lender.address);
 
             await poolConfigContract.connect(poolOwner).setAPR(1217);
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
 
             await poolContract
                 .connect(eaServiceAccount)
@@ -879,7 +819,6 @@ describe("Base Credit Pool", function () {
             let lenderBalance = await testTokenContract.balanceOf(lender.address);
 
             await poolConfigContract.connect(poolOwner).setAPR(1217);
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
 
             await poolContract
                 .connect(eaServiceAccount)
@@ -942,7 +881,6 @@ describe("Base Credit Pool", function () {
             let lenderBalance = await testTokenContract.balanceOf(lender.address);
 
             await poolConfigContract.connect(poolOwner).setAPR(1217);
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
 
             await poolContract
                 .connect(eaServiceAccount)
@@ -972,7 +910,6 @@ describe("Base Credit Pool", function () {
     describe("makePayment after account deleted", function () {
         it("Shall revert makePayment() if the account has been deleted", async function () {
             await poolConfigContract.connect(poolOwner).setAPR(1217);
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 2);
 
             await poolContract
                 .connect(eaServiceAccount)
@@ -1007,7 +944,6 @@ describe("Base Credit Pool", function () {
             let lenderBalance = await testTokenContract.balanceOf(lender.address);
 
             await poolConfigContract.connect(poolOwner).setAPR(1217);
-            await poolContract.connect(borrower).requestCredit(toToken(1_500_000), 30, 12);
 
             await poolContract
                 .connect(eaServiceAccount)
@@ -1129,7 +1065,6 @@ describe("Base Credit Pool", function () {
         describe("Common", function () {
             beforeEach(async function () {
                 await poolConfigContract.connect(poolOwner).setAPR(1217);
-                await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
 
                 await poolContract
                     .connect(eaServiceAccount)
@@ -1150,7 +1085,7 @@ describe("Base Credit Pool", function () {
                 await poolContract.refreshAccount(borrower.address);
                 let creditInfo = await poolContract.creditRecordMapping(borrower.address);
                 await expect(
-                    poolContract.triggerDefault(borrower.address)
+                    poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)
                 ).to.be.revertedWithCustomError(poolContract, "defaultTriggeredTooEarly");
 
                 expect(creditInfo.unbilledPrincipal).to.equal(1010002739726);
@@ -1168,7 +1103,7 @@ describe("Base Credit Pool", function () {
                 await poolContract.refreshAccount(borrower.address);
                 creditInfo = await poolContract.creditRecordMapping(borrower.address);
                 await expect(
-                    poolContract.triggerDefault(borrower.address)
+                    poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)
                 ).to.be.revertedWithCustomError(poolContract, "defaultTriggeredTooEarly");
 
                 expect(creditInfo.unbilledPrincipal).to.equal(1032205561651);
@@ -1458,7 +1393,6 @@ describe("Base Credit Pool", function () {
                 await poolConfigContract.connect(poolOwner).setAPR(1217);
                 await poolConfigContract.connect(poolOwner).setPoolDefaultGracePeriod(60);
 
-                await poolContract.connect(borrower).requestCredit(toToken(5_000_000), 30, 12);
                 await poolContract
                     .connect(eaServiceAccount)
                     .approveCredit(borrower.address, toToken(5_000_000), 30, 12, 1217);
@@ -1486,6 +1420,85 @@ describe("Base Credit Pool", function () {
 
                 expect(await poolContract.totalPoolValue()).to.equal(0);
             });
+        });
+
+        it("triggerDefault should reject non-EA callers", async function () {
+            await poolContract
+                .connect(eaServiceAccount)
+                .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
+            await poolContract.connect(borrower).drawdown(toToken(1_000_000));
+
+            // Advance to default-ready
+            await advanceClock(100);
+            await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
+
+            // borrower should be rejected
+            await expect(
+                poolContract.connect(borrower).triggerDefault(borrower.address)
+            ).to.be.revertedWithCustomError(poolContract, "evaluationAgentServiceAccountRequired");
+
+            // pdsServiceAccount should be rejected
+            await expect(
+                poolContract.connect(pdsServiceAccount).triggerDefault(borrower.address)
+            ).to.be.revertedWithCustomError(poolContract, "evaluationAgentServiceAccountRequired");
+        });
+
+        it("Defaulted state should not be reset to GoodStanding by _updateDueInfo", async function () {
+            await poolConfigContract.connect(poolOwner).setAPR(1217);
+            await poolConfigContract.connect(poolOwner).setPoolDefaultGracePeriod(60);
+
+            await poolContract
+                .connect(eaServiceAccount)
+                .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
+            await poolContract.connect(borrower).drawdown(toToken(1_000_000));
+            let blockBefore = await ethers.provider.getBlock();
+            let dueDate = blockBefore.timestamp + 2592000;
+
+            // Advance 3 periods to become default-ready
+            let nextDate = dueDate + 1;
+            await mineNextBlockWithTimestamp(nextDate);
+            dueDate += 2592000;
+            await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
+
+            nextDate = dueDate + 1;
+            await mineNextBlockWithTimestamp(nextDate);
+            dueDate += 2592000;
+            await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
+
+            nextDate = dueDate + 1;
+            await mineNextBlockWithTimestamp(nextDate);
+            dueDate += 2592000;
+
+            // Trigger default
+            await poolContract.connect(eaServiceAccount).triggerDefault(borrower.address);
+            let record = await poolContract.creditRecordMapping(borrower.address);
+            expect(record.state).to.equal(5); // Defaulted
+
+            // Pay enough to clear totalDue but not payoff
+            await testTokenContract.connect(borrower).mint(borrower.address, toToken(200_000));
+            await testTokenContract
+                .connect(borrower)
+                .approve(poolContract.address, toToken(200_000));
+
+            nextDate = dueDate - 20 * 24 * 3600;
+            await setNextBlockTimestamp(nextDate);
+            await poolContract.connect(borrower).makePayment(borrower.address, toToken(25_000));
+
+            record = await poolContract.creditRecordMapping(borrower.address);
+            expect(record.state).to.equal(5); // Still Defaulted
+
+            // Advance past dueDate so _updateDueInfo recalculates
+            nextDate = dueDate + 1;
+            await mineNextBlockWithTimestamp(nextDate);
+            dueDate += 2592000;
+
+            // Small payment triggers _updateDueInfo with missedPeriods=0
+            await poolContract.connect(borrower).makePayment(borrower.address, toToken(50_000));
+
+            record = await poolContract.creditRecordMapping(borrower.address);
+            // With patch: state should remain Defaulted (5)
+            // Without patch (bug): state would become GoodStanding (3)
+            expect(record.state).to.equal(5);
         });
     });
 
@@ -1539,7 +1552,6 @@ describe("Base Credit Pool", function () {
         });
 
         it("Should withdraw protocol fee", async function () {
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
@@ -1565,7 +1577,6 @@ describe("Base Credit Pool", function () {
         });
 
         it("Should withdraw pool owner fee", async function () {
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
@@ -1591,7 +1602,6 @@ describe("Base Credit Pool", function () {
         });
 
         it("Should withdraw ea fee", async function () {
-            await poolContract.connect(borrower).requestCredit(toToken(1_000_000), 30, 12);
             await poolContract
                 .connect(eaServiceAccount)
                 .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);

--- a/test/BaseCreditPoolTest.js
+++ b/test/BaseCreditPoolTest.js
@@ -510,6 +510,19 @@ describe("Base Credit Pool", function () {
     });
 
     describe("Account update by service account", function () {
+        it("Shall reject refreshAccount from non-PDS caller", async function () {
+            await poolContract
+                .connect(eaServiceAccount)
+                .approveCredit(borrower.address, toToken(1_000_000), 30, 12, 1217);
+            await poolContract.connect(borrower).drawdown(toToken(1_000_000));
+            await expect(
+                poolContract.connect(borrower).refreshAccount(borrower.address)
+            ).to.be.revertedWithCustomError(
+                poolContract,
+                "paymentDetectionServiceAccountRequired"
+            );
+        });
+
         it("Shall not emit BillRefreshed event when the bill should not be refreshed", async function () {
             await poolContract
                 .connect(eaServiceAccount)
@@ -1082,7 +1095,7 @@ describe("Base Credit Pool", function () {
                 await mineNextBlockWithTimestamp(nextDate);
                 dueDate += 2592000;
 
-                await poolContract.refreshAccount(borrower.address);
+                await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
                 let creditInfo = await poolContract.creditRecordMapping(borrower.address);
                 await expect(
                     poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)
@@ -1100,7 +1113,7 @@ describe("Base Credit Pool", function () {
                 await mineNextBlockWithTimestamp(nextDate);
                 dueDate += 2592000;
 
-                await poolContract.refreshAccount(borrower.address);
+                await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
                 creditInfo = await poolContract.creditRecordMapping(borrower.address);
                 await expect(
                     poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)
@@ -1173,11 +1186,11 @@ describe("Base Credit Pool", function () {
                 nextDate = dueDate + 1;
                 await mineNextBlockWithTimestamp(nextDate);
                 dueDate += 2592000;
-                await poolContract.refreshAccount(borrower.address);
+                await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
                 nextDate = dueDate + 1;
                 await mineNextBlockWithTimestamp(nextDate);
                 dueDate += 2592000;
-                await poolContract.refreshAccount(borrower.address);
+                await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
                 nextDate = dueDate + 1;
                 await mineNextBlockWithTimestamp(nextDate);
                 dueDate += 2592000;
@@ -1403,11 +1416,11 @@ describe("Base Credit Pool", function () {
                 nextDate = dueDate + 1;
                 await mineNextBlockWithTimestamp(nextDate);
                 dueDate += 2592000;
-                await poolContract.refreshAccount(borrower.address);
+                await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
                 nextDate = dueDate + 1;
                 await mineNextBlockWithTimestamp(nextDate);
                 dueDate += 2592000;
-                await poolContract.refreshAccount(borrower.address);
+                await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
                 nextDate = dueDate + 1;
                 await mineNextBlockWithTimestamp(nextDate);
                 dueDate += 2592000;

--- a/test/CreditLineIntegrationTest.js
+++ b/test/CreditLineIntegrationTest.js
@@ -86,27 +86,7 @@ describe("Credit Line Integration Test", async function () {
     });
 
     it("Day 0: Initial drawdown", async function () {
-        // Establish credit line
-        await poolContract.connect(borrower).requestCredit(toToken(5040), 30, 12);
-        record = await poolContract.creditRecordMapping(borrower.address);
-        recordStatic = await poolContract.creditRecordStaticMapping(borrower.address);
-        checkRecord(
-            record,
-            recordStatic,
-            toToken(5040),
-            0,
-            "SKIP",
-            0,
-            0,
-            0,
-            0,
-            12,
-            1217,
-            30,
-            1,
-            0
-        );
-
+        // requestCredit is disabled (no-op), go directly to approveCredit
         await poolContract
             .connect(eaServiceAccount)
             .approveCredit(borrower.address, toToken(5040), 30, 12, 1217);

--- a/test/HDTTest.js
+++ b/test/HDTTest.js
@@ -65,5 +65,28 @@ describe("HDT - some negative cases", function () {
                 "zeroAmountProvided"
             );
         });
+
+        it("Cannot transfer HDT between accounts", async function () {
+            // Mint some tokens: with totalSupply=0, convertToShares returns assets directly
+            await pool.setValue(0);
+            await pool.mintAmount(deployer.address, toToken(1_000));
+            // Now set pool value so the token has asset backing
+            await pool.setValue(toToken(1_000));
+            expect(await hdtContract.balanceOf(deployer.address)).to.be.gt(0);
+
+            const [, , recipient] = await ethers.getSigners();
+            // transfer should be blocked
+            await expect(
+                hdtContract.transfer(recipient.address, toToken(100))
+            ).to.be.revertedWithCustomError(hdtContract, "transferNotAllowed");
+
+            // transferFrom should also be blocked
+            await hdtContract.approve(recipient.address, toToken(100));
+            await expect(
+                hdtContract
+                    .connect(recipient)
+                    .transferFrom(deployer.address, recipient.address, toToken(100))
+            ).to.be.revertedWithCustomError(hdtContract, "transferNotAllowed");
+        });
     });
 });

--- a/test/InvoiceFactoringTest.js
+++ b/test/InvoiceFactoringTest.js
@@ -978,7 +978,7 @@ describe("Invoice Factoring", function () {
                 // pay period 1
                 await advanceClock(30);
                 await ethers.provider.send("evm_mine", []);
-                await poolContract.refreshAccount(borrower.address);
+                await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
 
                 await expect(
                     poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)
@@ -997,7 +997,7 @@ describe("Invoice Factoring", function () {
 
                 // pay period 2
                 await advanceClock(30);
-                await poolContract.refreshAccount(borrower.address);
+                await poolContract.connect(pdsServiceAccount).refreshAccount(borrower.address);
 
                 await expect(
                     poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)

--- a/test/InvoiceFactoringTest.js
+++ b/test/InvoiceFactoringTest.js
@@ -960,7 +960,7 @@ describe("Invoice Factoring", function () {
         describe("Default flow", async function () {
             it("Writeoff less than pool value", async function () {
                 await expect(
-                    poolContract.triggerDefault(borrower.address)
+                    poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)
                 ).to.be.revertedWithCustomError(poolContract, "defaultTriggeredTooEarly");
                 // post withdraw
                 expect(await hdtContract.withdrawableFundsOf(poolOwnerTreasury.address)).to.equal(
@@ -981,7 +981,7 @@ describe("Invoice Factoring", function () {
                 await poolContract.refreshAccount(borrower.address);
 
                 await expect(
-                    poolContract.triggerDefault(borrower.address)
+                    poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)
                 ).to.be.revertedWithCustomError(poolContract, "defaultTriggeredTooEarly");
                 expect(await hdtContract.withdrawableFundsOf(poolOwnerTreasury.address)).to.equal(
                     toToken(1_002_760)
@@ -1000,7 +1000,7 @@ describe("Invoice Factoring", function () {
                 await poolContract.refreshAccount(borrower.address);
 
                 await expect(
-                    poolContract.triggerDefault(borrower.address)
+                    poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)
                 ).to.be.revertedWithCustomError(poolContract, "defaultTriggeredTooEarly");
                 expect(await hdtContract.withdrawableFundsOf(poolOwnerTreasury.address)).to.equal(
                     1004214400000
@@ -1042,13 +1042,13 @@ describe("Invoice Factoring", function () {
 
             it("Multiple partial payments after default", async function () {
                 await expect(
-                    poolContract.triggerDefault(borrower.address)
+                    poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)
                 ).to.be.revertedWithCustomError(poolContract, "defaultTriggeredTooEarly");
 
                 await advanceClock(30);
                 await advanceClock(30);
                 await expect(
-                    poolContract.triggerDefault(borrower.address)
+                    poolContract.connect(eaServiceAccount).triggerDefault(borrower.address)
                 ).to.be.revertedWithCustomError(poolContract, "defaultTriggeredTooEarly");
 
                 await advanceClock(30);


### PR DESCRIPTION
- Patch 1: disable requestCredit (no-op, use approveCredit instead)
- Patch 2: restrict triggerDefault to EA service account
- Patch 3: refreshAccount only processes GoodStanding/Delayed (silent no-op otherwise)
- Patch 4: prevent Defaulted state from being reset to GoodStanding in _updateDueInfo
